### PR TITLE
feat: Resolve map-only objects to HashMap types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",

--- a/crates/oas3-gen/src/generator/converter/common.rs
+++ b/crates/oas3-gen/src/generator/converter/common.rs
@@ -118,6 +118,11 @@ pub(crate) trait SchemaExt {
 
   /// Returns true if the schema is a discriminated base type with a non-empty mapping.
   fn is_discriminated_base_type(&self) -> bool;
+
+  /// Returns true if the schema has no type constraints (no properties, no type info).
+  /// An empty schema `{}` or one with only `additionalProperties: {}` both return true,
+  /// as neither constrains the shape of the data.
+  fn is_empty_object(&self) -> bool;
 }
 
 impl SchemaExt for ObjectSchema {
@@ -229,5 +234,14 @@ impl SchemaExt for ObjectSchema {
       .and_then(|d| d.mapping.as_ref().map(|m| !m.is_empty()))
       .unwrap_or(false)
       && !self.properties.is_empty()
+  }
+
+  fn is_empty_object(&self) -> bool {
+    self.properties.is_empty()
+      && self.one_of.is_empty()
+      && self.any_of.is_empty()
+      && self.all_of.is_empty()
+      && self.enum_values.is_empty()
+      && self.schema_type.is_none()
   }
 }

--- a/crates/oas3-gen/src/generator/converter/structs.rs
+++ b/crates/oas3-gen/src/generator/converter/structs.rs
@@ -492,12 +492,8 @@ impl FieldProcessor {
         Schema::Boolean(b) if !b.0 => {
           serde_attrs.push(SerdeAttribute::DenyUnknownFields);
         }
-        Schema::Object(schema_ref) => {
-          let additional_schema = schema_ref
-            .resolve(self.type_resolver.graph().spec())
-            .with_context(|| "Schema resolution failed for additionalProperties")?;
-
-          let value_type = self.type_resolver.resolve_type(&additional_schema)?;
+        Schema::Object(_) => {
+          let value_type = self.type_resolver.resolve_additional_properties_type(additional)?;
           let map_type = TypeRef::new(format!(
             "std::collections::HashMap<String, {}>",
             value_type.to_rust_type()


### PR DESCRIPTION
Objects defined with only additionalProperties and no properties are now
correctly resolved to HashMap<String, T> where T is derived from the
additionalProperties schema. This includes proper handling for:
- Primitive types (bool, string, integer, etc.)
- Reference types ($ref to other schemas)
- Empty schemas ({}) which resolve to serde_json::Value
- Boolean schemas (true/false)

Adds is_empty_object() helper to detect unconstrained schemas and
resolve_additional_properties_type() for centralized value type resolution.