### PR TITLE
refactor: Improve type safety and attribute handling in code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 .idea/
 .vscode/
 .zed/
+
+.env
+.env.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "oas3-gen"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "any_ascii",
  "anyhow",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "oas3-gen-support"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "better_default",
@@ -1330,9 +1330,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.25"
+version = "0.12.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
+checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.22.3"
+version = "0.22.4"
 authors = ["Matthew Jarjoura <eklipse2k8>"]
 categories = [
   "command-line-utilities",
@@ -37,7 +37,7 @@ split-debuginfo = "unpacked"
 
 [workspace.dependencies]
 # Workspace Members
-oas3-gen-support = { path = "crates/oas3-gen-support", version = "0.22.3" }
+oas3-gen-support = { path = "crates/oas3-gen-support", version = "0.22.4" }
 
 # External Dependencies
 any_ascii = { version = "0.3" }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- prettier-ignore-start -->
 [![crates.io](https://img.shields.io/crates/v/oas3-gen?label=latest)](https://crates.io/crates/oas3-gen)
-[![dependency status](https://deps.rs/crate/oas3-gen/0.22.3/status.svg)](https://deps.rs/crate/oas3-gen/0.22.3)
+[![dependency status](https://deps.rs/crate/oas3-gen/0.22.4/status.svg)](https://deps.rs/crate/oas3-gen/0.22.4)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 [![openapi](https://badgen.net/badge/OAS/v3.1.1?list=1&color=purple)](https://github.com/OAI/OpenAPI-Specification)
 <!-- prettier-ignore-end -->

--- a/crates/oas3-gen/fixtures/union_serde/types.rs
+++ b/crates/oas3-gen/fixtures/union_serde/types.rs
@@ -86,9 +86,7 @@ pub struct Base64ImageSource {
   pub data: Vec<u8>,
   pub media_type: String,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("base64".to_string()))]
   pub r#type: Option<String>,
 }
@@ -101,9 +99,7 @@ pub struct CitationAnnotation {
   pub source: String,
   pub start: i64,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("citation".to_string()))]
   pub r#type: Option<String>,
 }
@@ -115,9 +111,7 @@ pub struct CodeBlock {
   pub code: String,
   pub language: Option<String>,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("code".to_string()))]
   pub r#type: Option<String>,
 }
@@ -189,9 +183,7 @@ pub struct ContentBlockDeltaEvent {
   pub delta: Box<Delta>,
   pub index: i64,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("content_block_delta".to_string()))]
   pub r#type: Option<String>,
 }
@@ -202,9 +194,7 @@ pub struct ContentBlockStartEvent {
   pub content_block: Box<ContentBlock>,
   pub index: i64,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("content_block_start".to_string()))]
   pub r#type: Option<String>,
 }
@@ -213,9 +203,7 @@ pub struct ContentBlockStartEvent {
 pub struct ContentBlockStopEvent {
   pub index: i64,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("content_block_stop".to_string()))]
   pub r#type: Option<String>,
 }
@@ -406,9 +394,7 @@ pub struct ImageBlock {
   ///Image source can be base64 or URL
   pub source: Box<ImageSource>,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("image".to_string()))]
   pub r#type: Option<String>,
 }
@@ -463,9 +449,7 @@ impl<'de> serde::Deserialize<'de> for ImageSource {
 pub struct InputJsonDelta {
   pub partial_json: String,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("input_json_delta".to_string()))]
   pub r#type: Option<String>,
 }
@@ -476,9 +460,7 @@ pub struct LinkAnnotation {
   pub end: i64,
   pub start: i64,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("link".to_string()))]
   pub r#type: Option<String>,
   #[validate(url, length(min = 1u64))]
@@ -510,9 +492,7 @@ pub struct Message {
 pub struct MessageStartEvent {
   pub message: Message,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("message_start".to_string()))]
   pub r#type: Option<String>,
 }
@@ -520,9 +500,7 @@ pub struct MessageStartEvent {
 #[serde(default)]
 pub struct MessageStopEvent {
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("message_stop".to_string()))]
   pub r#type: Option<String>,
 }
@@ -546,9 +524,7 @@ pub enum NullableStringOrNumber {
 #[serde(default)]
 pub struct PingEvent {
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("ping".to_string()))]
   pub r#type: Option<String>,
 }
@@ -616,9 +592,7 @@ pub struct TextBlock {
   #[validate(length(min = 1u64))]
   pub text: String,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("text".to_string()))]
   pub r#type: Option<String>,
 }
@@ -627,9 +601,7 @@ pub struct TextBlock {
 pub struct TextDelta {
   pub text: String,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("text_delta".to_string()))]
   pub r#type: Option<String>,
 }
@@ -643,9 +615,7 @@ pub struct ToolResultBlock {
   #[validate(length(min = 1u64))]
   pub tool_use_id: String,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("tool_result".to_string()))]
   pub r#type: Option<String>,
 }
@@ -712,9 +682,7 @@ pub struct ToolUseBlock {
   #[validate(length(min = 1u64))]
   pub name: String,
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("tool_use".to_string()))]
   pub r#type: Option<String>,
 }
@@ -723,9 +691,7 @@ pub struct ToolUseBlock {
 #[serde(default)]
 pub struct UrlImageSource {
   #[doc(hidden)]
-  #[serde(rename = "type")]
-  #[serde(skip_deserializing)]
-  #[serde(default)]
+  #[serde(rename = "type", skip_deserializing, default)]
   #[default(Some("url".to_string()))]
   pub r#type: Option<String>,
   #[validate(url, length(min = 1u64))]

--- a/crates/oas3-gen/src/generator/ast/mod.rs
+++ b/crates/oas3-gen/src/generator/ast/mod.rs
@@ -1,5 +1,6 @@
 mod derives;
 pub mod lints;
+mod outer_attrs;
 pub(super) mod serde_attrs;
 mod status_codes;
 pub mod tokens;
@@ -13,6 +14,7 @@ use derive_builder::Builder;
 pub use derives::{DeriveTrait, DerivesProvider, SerdeImpl};
 use http::Method;
 pub use lints::LintConfig;
+pub use outer_attrs::OuterAttr;
 pub use serde_attrs::SerdeAttribute;
 pub use status_codes::{StatusCodeToken, status_code_to_variant_name};
 pub use tokens::{
@@ -244,7 +246,7 @@ pub struct StructDef {
   pub docs: Vec<String>,
   pub fields: Vec<FieldDef>,
   pub serde_attrs: Vec<SerdeAttribute>,
-  pub outer_attrs: Vec<String>,
+  pub outer_attrs: Vec<OuterAttr>,
   pub methods: Vec<StructMethod>,
   pub kind: StructKind,
   pub serde_mode: SerdeMode,
@@ -267,7 +269,6 @@ pub struct StructMethod {
   pub name: MethodNameToken,
   pub docs: Vec<String>,
   pub kind: StructMethodKind,
-  pub attrs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -357,7 +358,8 @@ pub struct FieldDef {
   pub docs: Vec<String>,
   pub rust_type: TypeRef,
   pub serde_attrs: Vec<SerdeAttribute>,
-  pub extra_attrs: Vec<String>,
+  /// Whether to emit `#[doc(hidden)]` for this field (used for discriminator fields)
+  pub doc_hidden: bool,
   pub validation_attrs: Vec<ValidationAttribute>,
   pub default_value: Option<serde_json::Value>,
   pub example_value: Option<serde_json::Value>,
@@ -381,7 +383,7 @@ pub struct EnumDef {
   pub variants: Vec<VariantDef>,
   pub discriminator: Option<String>,
   pub serde_attrs: Vec<SerdeAttribute>,
-  pub outer_attrs: Vec<String>,
+  pub outer_attrs: Vec<OuterAttr>,
   pub case_insensitive: bool,
   pub methods: Vec<EnumMethod>,
   pub serde_mode: SerdeMode,

--- a/crates/oas3-gen/src/generator/ast/outer_attrs.rs
+++ b/crates/oas3-gen/src/generator/ast/outer_attrs.rs
@@ -1,0 +1,27 @@
+use proc_macro2::TokenStream;
+use quote::{ToTokens, quote};
+
+/// Typed outer attributes for structs and enums.
+///
+/// Replaces the stringly-typed `Vec<String>` approach with a type-safe enum
+/// representing all supported outer attributes in generated code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OuterAttr {
+  /// Skips serializing fields that are `None`.
+  /// Renders as `#[oas3_gen_support::skip_serializing_none]`
+  SkipSerializingNone,
+  /// Marks the type as non-exhaustive.
+  /// Renders as `#[non_exhaustive]`
+  #[allow(dead_code)] // Reserved for future use
+  NonExhaustive,
+}
+
+impl ToTokens for OuterAttr {
+  fn to_tokens(&self, tokens: &mut TokenStream) {
+    let attr = match self {
+      OuterAttr::SkipSerializingNone => quote! { #[oas3_gen_support::skip_serializing_none] },
+      OuterAttr::NonExhaustive => quote! { #[non_exhaustive] },
+    };
+    tokens.extend(attr);
+  }
+}

--- a/crates/oas3-gen/src/generator/ast/serde_attrs.rs
+++ b/crates/oas3-gen/src/generator/ast/serde_attrs.rs
@@ -1,25 +1,37 @@
-use strum::Display;
+use proc_macro2::TokenStream;
+use quote::{ToTokens, quote};
 
 /// Represents a serde attribute applied to structs, fields, or enum variants.
 ///
 /// These attributes control serialization and deserialization behavior in generated Rust code.
 /// Each variant maps directly to a serde attribute that will be rendered in the output.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SerdeAttribute {
-  #[strum(serialize = "rename = \"{0}\"")]
   Rename(String),
-  #[strum(serialize = "alias = \"{0}\"")]
   Alias(String),
-  #[strum(serialize = "default")]
   Default,
-  #[strum(serialize = "flatten")]
   Flatten,
-  #[strum(serialize = "skip")]
   Skip,
-  #[strum(serialize = "skip_deserializing")]
   SkipDeserializing,
-  #[strum(serialize = "deny_unknown_fields")]
   DenyUnknownFields,
-  #[strum(serialize = "untagged")]
   Untagged,
+  /// Internal enum tagging: `#[serde(tag = "...")]`
+  Tag(String),
+}
+
+impl ToTokens for SerdeAttribute {
+  fn to_tokens(&self, tokens: &mut TokenStream) {
+    let attr = match self {
+      SerdeAttribute::Rename(name) => quote! { rename = #name },
+      SerdeAttribute::Alias(name) => quote! { alias = #name },
+      SerdeAttribute::Default => quote! { default },
+      SerdeAttribute::Flatten => quote! { flatten },
+      SerdeAttribute::Skip => quote! { skip },
+      SerdeAttribute::SkipDeserializing => quote! { skip_deserializing },
+      SerdeAttribute::DenyUnknownFields => quote! { deny_unknown_fields },
+      SerdeAttribute::Untagged => quote! { untagged },
+      SerdeAttribute::Tag(field) => quote! { tag = #field },
+    };
+    tokens.extend(attr);
+  }
 }

--- a/crates/oas3-gen/src/generator/codegen/tests/enum_tests.rs
+++ b/crates/oas3-gen/src/generator/codegen/tests/enum_tests.rs
@@ -1,8 +1,8 @@
 use crate::generator::{
   ast::{
     ContentCategory, DiscriminatedEnumDef, DiscriminatedVariant, EnumDef, EnumMethod, EnumMethodKind, EnumToken,
-    EnumVariantToken, ResponseEnumDef, ResponseVariant, RustPrimitive, SerdeAttribute, SerdeMode, StatusCodeToken,
-    StructToken, TypeRef, VariantContent, VariantDef,
+    EnumVariantToken, OuterAttr, ResponseEnumDef, ResponseVariant, RustPrimitive, SerdeAttribute, SerdeMode,
+    StatusCodeToken, StructToken, TypeRef, VariantContent, VariantDef,
   },
   codegen::{
     Visibility,
@@ -183,7 +183,7 @@ fn test_enum_variant_attributes() {
     variants: vec![make_unit_variant("Yes"), make_unit_variant("No")],
     discriminator: None,
     serde_attrs: vec![],
-    outer_attrs: vec!["#[non_exhaustive]".to_string()],
+    outer_attrs: vec![OuterAttr::NonExhaustive],
     case_insensitive: false,
     methods: vec![],
     ..Default::default()

--- a/crates/oas3-gen/src/generator/codegen/tests/struct_tests.rs
+++ b/crates/oas3-gen/src/generator/codegen/tests/struct_tests.rs
@@ -17,7 +17,6 @@ fn base_struct(kind: StructKind) -> StructDef {
       name: FieldNameToken::new("field"),
       rust_type: TypeRef::new("String"),
       serde_attrs: vec![],
-      extra_attrs: vec![],
       validation_attrs: vec![ValidationAttribute::Length {
         min: Some(1),
         max: None,
@@ -42,7 +41,6 @@ fn make_response_parser_struct(variant: ResponseVariant) -> StructDef {
       response_enum: EnumToken::new("ResponseEnum"),
       variants: vec![variant],
     },
-    attrs: vec![],
   });
   def
 }
@@ -53,7 +51,6 @@ fn make_path_struct(field_name: &str, rust_type: &str, path_literal: &str) -> St
     name: FieldNameToken::new(field_name),
     rust_type: TypeRef::new(rust_type),
     serde_attrs: vec![],
-    extra_attrs: vec![],
     validation_attrs: vec![],
     default_value: None,
     ..Default::default()
@@ -70,7 +67,6 @@ fn make_path_struct(field_name: &str, rust_type: &str, path_literal: &str) -> St
       ],
       query_params: vec![],
     },
-    attrs: vec![],
   });
   def
 }
@@ -126,7 +122,6 @@ fn renders_struct_methods() {
         style: None,
       }],
     },
-    attrs: vec![],
   });
   let tokens = structs::StructGenerator::new(&BTreeMap::new(), Visibility::Public).generate(&def);
   let code = tokens.to_string();
@@ -258,7 +253,6 @@ fn renders_path_with_mixed_parameters() {
       name: FieldNameToken::new("user_id"),
       rust_type: TypeRef::new("i64"),
       serde_attrs: vec![],
-      extra_attrs: vec![],
       validation_attrs: vec![],
       default_value: None,
       ..Default::default()
@@ -267,7 +261,6 @@ fn renders_path_with_mixed_parameters() {
       name: FieldNameToken::new("post_slug"),
       rust_type: TypeRef::new("String"),
       serde_attrs: vec![],
-      extra_attrs: vec![],
       validation_attrs: vec![],
       default_value: None,
       ..Default::default()
@@ -289,7 +282,6 @@ fn renders_path_with_mixed_parameters() {
       ],
       query_params: vec![],
     },
-    attrs: vec![],
   });
   let tokens = structs::StructGenerator::new(&BTreeMap::new(), Visibility::Public).generate(&def);
   let code = tokens.to_string();

--- a/crates/oas3-gen/src/generator/converter/discriminator.rs
+++ b/crates/oas3-gen/src/generator/converter/discriminator.rs
@@ -15,8 +15,6 @@ use crate::generator::{
   schema_registry::{ReferenceExtractor, SchemaRegistry},
 };
 
-const HIDDEN: &str = "#[doc(hidden)]";
-
 pub(crate) struct DiscriminatorInfo {
   pub value: Option<DefaultAtom>,
   pub is_base: bool,
@@ -26,7 +24,7 @@ pub(crate) struct DiscriminatorInfo {
 pub(crate) struct DiscriminatorAttributesResult {
   pub metadata: FieldMetadata,
   pub serde_attrs: Vec<SerdeAttribute>,
-  pub extra_attrs: Vec<String>,
+  pub doc_hidden: bool,
 }
 
 pub(crate) fn get_discriminator_info(
@@ -78,7 +76,7 @@ pub(crate) fn apply_discriminator_attributes(
     return DiscriminatorAttributesResult {
       metadata,
       serde_attrs,
-      extra_attrs: vec![],
+      doc_hidden: false,
     };
   }
 
@@ -86,7 +84,6 @@ pub(crate) fn apply_discriminator_attributes(
 
   metadata.docs.clear();
   metadata.validation_attrs.clear();
-  let extra_attrs = vec![HIDDEN.to_string()];
 
   if let Some(ref disc_value) = disc_info.value {
     metadata.default_value = Some(serde_json::Value::String(disc_value.to_string()));
@@ -103,7 +100,7 @@ pub(crate) fn apply_discriminator_attributes(
   DiscriminatorAttributesResult {
     metadata,
     serde_attrs,
-    extra_attrs,
+    doc_hidden: true,
   }
 }
 

--- a/crates/oas3-gen/src/generator/converter/path_renderer.rs
+++ b/crates/oas3-gen/src/generator/converter/path_renderer.rs
@@ -49,7 +49,6 @@ pub(crate) fn build_render_path_method(
       segments: parse_path_segments(path, path_params),
       query_params: query_parameters,
     },
-    attrs: vec![],
   }
 }
 

--- a/crates/oas3-gen/src/generator/converter/responses.rs
+++ b/crates/oas3-gen/src/generator/converter/responses.rs
@@ -174,6 +174,5 @@ pub(crate) fn build_parse_response_method(response_enum: &EnumToken, variants: &
       response_enum: response_enum.clone(),
       variants: variants.to_vec(),
     },
-    attrs: vec![],
   }
 }

--- a/crates/oas3-gen/src/generator/converter/tests/structs.rs
+++ b/crates/oas3-gen/src/generator/converter/tests/structs.rs
@@ -115,7 +115,7 @@ fn test_discriminator_with_enum_remains_visible() -> anyhow::Result<()> {
     .expect("role field should exist");
 
   assert!(
-    !role_field.extra_attrs.iter().any(|a| a.contains("doc(hidden)")),
+    !role_field.doc_hidden,
     "role field should not be hidden when discriminator has enum values"
   );
   assert!(
@@ -180,10 +180,7 @@ fn test_discriminator_without_enum_is_hidden() -> anyhow::Result<()> {
     .find(|f| f.name == "odata_type")
     .expect("odata_type field should exist");
 
-  assert!(
-    odata_field.extra_attrs.iter().any(|a| a.contains("doc(hidden)")),
-    "odata_type field should be hidden"
-  );
+  assert!(odata_field.doc_hidden, "odata_type field should be hidden");
   assert!(
     odata_field.serde_attrs.contains(&SerdeAttribute::Skip),
     "odata_type field should be skipped"
@@ -446,7 +443,7 @@ fn test_apply_discriminator_attributes_none_returns_unchanged() {
   assert_eq!(result.metadata.docs, metadata.docs);
   assert_eq!(result.metadata.validation_attrs.len(), 1);
   assert_eq!(result.serde_attrs, serde_attrs);
-  assert!(result.extra_attrs.is_empty());
+  assert!(!result.doc_hidden);
 }
 
 #[test]
@@ -474,7 +471,7 @@ fn test_apply_discriminator_attributes_child_discriminator_hides_and_sets_value(
   );
   assert!(result.serde_attrs.contains(&SerdeAttribute::SkipDeserializing));
   assert!(result.serde_attrs.contains(&SerdeAttribute::Default));
-  assert!(result.extra_attrs.iter().any(|a| a.contains("doc(hidden)")));
+  assert!(result.doc_hidden);
 }
 
 #[test]
@@ -506,7 +503,7 @@ fn test_apply_discriminator_attributes_base_without_enum_hides_and_skips() {
     vec![SerdeAttribute::Skip],
     "only Skip should remain"
   );
-  assert!(result.extra_attrs.iter().any(|a| a.contains("doc(hidden)")));
+  assert!(result.doc_hidden);
 }
 
 #[test]
@@ -551,7 +548,7 @@ fn test_apply_discriminator_attributes_base_with_enum_remains_visible() {
     "validation attrs should be preserved"
   );
   assert_eq!(result.serde_attrs, serde_attrs, "serde attrs should be unchanged");
-  assert!(result.extra_attrs.is_empty(), "should not be hidden");
+  assert!(!result.doc_hidden, "should not be hidden");
 }
 
 #[test]

--- a/crates/oas3-gen/src/generator/orchestrator.rs
+++ b/crates/oas3-gen/src/generator/orchestrator.rs
@@ -8,7 +8,10 @@ use crate::generator::{
   analyzer::{self, ErrorAnalyzer},
   ast::{LintConfig, OperationInfo, OperationKind, RustType},
   codegen::{self, Visibility, client::ClientGenerator, metadata::CodeMetadata},
-  converter::{CodegenConfig, SchemaConverter, TypeUsageRecorder, operations::OperationConverter},
+  converter::{
+    CodegenConfig, EnumCasePolicy, EnumDeserializePolicy, EnumHelperPolicy, ODataPolicy, SchemaConverter,
+    TypeUsageRecorder, operations::OperationConverter,
+  },
   naming::inference::InlineTypeScanner,
   operation_registry::OperationRegistry,
   schema_registry::SchemaRegistry,
@@ -167,10 +170,26 @@ impl Orchestrator {
     };
 
     let config = CodegenConfig {
-      preserve_case_variants: self.preserve_case_variants,
-      case_insensitive_enums: self.case_insensitive_enums,
-      no_helpers: self.no_helpers,
-      odata_support: self.odata_support,
+      enum_case: if self.preserve_case_variants {
+        EnumCasePolicy::Preserve
+      } else {
+        EnumCasePolicy::Deduplicate
+      },
+      enum_helpers: if self.no_helpers {
+        EnumHelperPolicy::Disable
+      } else {
+        EnumHelperPolicy::Generate
+      },
+      enum_deserialize: if self.case_insensitive_enums {
+        EnumDeserializePolicy::CaseInsensitive
+      } else {
+        EnumDeserializePolicy::CaseSensitive
+      },
+      odata: if self.odata_support {
+        ODataPolicy::Enabled
+      } else {
+        ODataPolicy::Disabled
+      },
     };
 
     let graph = Arc::new(graph);

--- a/crates/oas3-gen/src/tests/common.rs
+++ b/crates/oas3-gen/src/tests/common.rs
@@ -3,7 +3,10 @@ use std::{collections::BTreeMap, sync::Arc};
 use oas3::spec::{ObjectSchema, Spec};
 use serde_json::json;
 
-use crate::generator::{converter::CodegenConfig, schema_registry::SchemaRegistry};
+use crate::generator::{
+  converter::{CodegenConfig, EnumCasePolicy, EnumHelperPolicy},
+  schema_registry::SchemaRegistry,
+};
 
 pub(crate) fn create_test_spec(schemas: BTreeMap<String, ObjectSchema>) -> Spec {
   let mut spec_json = json!({
@@ -30,28 +33,19 @@ pub(crate) fn create_test_graph(schemas: BTreeMap<String, ObjectSchema>) -> Arc<
 }
 
 pub(crate) fn default_config() -> CodegenConfig {
-  CodegenConfig {
-    preserve_case_variants: false,
-    case_insensitive_enums: false,
-    no_helpers: false,
-    odata_support: false,
-  }
+  CodegenConfig::default()
 }
 
 pub(crate) fn config_with_preserve_case() -> CodegenConfig {
   CodegenConfig {
-    preserve_case_variants: true,
-    case_insensitive_enums: false,
-    no_helpers: false,
-    odata_support: false,
+    enum_case: EnumCasePolicy::Preserve,
+    ..Default::default()
   }
 }
 
 pub(crate) fn config_with_no_helpers() -> CodegenConfig {
   CodegenConfig {
-    preserve_case_variants: false,
-    case_insensitive_enums: false,
-    no_helpers: true,
-    odata_support: false,
+    enum_helpers: EnumHelperPolicy::Disable,
+    ..Default::default()
   }
 }


### PR DESCRIPTION
This commit refactors the code generation logic to use type-safe enums for attributes and configuration, enhancing clarity and preventing errors associated with stringly-typed values.

Key changes include:
- Introducing `OuterAttr` enum for common outer attributes (e.g., `#[oas3_gen_support::skip_serializing_none]`, `#[non_exhaustive]`).
- Enhancing `SerdeAttribute` and `ValidationAttribute` to implement `ToTokens` for direct code generation and better integration.
- Consolidating multiple `#[serde(...)]` and `#[validate(...)]` attributes into single, combined attributes during code generation.
- Replacing string-based `extra_attrs` with a `doc_hidden: bool` flag for clearer intent regarding discriminator fields.
- Refactoring `CodegenConfig` to use explicit enum policies (`EnumCasePolicy`, `EnumHelperPolicy`, `EnumDeserializePolicy`, `ODataPolicy`) instead of boolean flags.
- Introducing `StructSummary` to cache essentil struct characteristics, optimizing enum helper constructor generation.
- Updating related analyzer, converter, and codegen logic to align with the new attribute and configuration structures.