### PR TITLE
feat: add YAML support for OpenAPI specifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ OpenAPI-to-Rust code generator that parses OpenAPI 3.1 specifications and genera
 ```bash
 cargo build                    # Build
 cargo test                     # Test
-cargo run -- generate types -i spec.json -o types.rs   # Generate types
+cargo run -- generate types -i spec.json -o types.rs   # Generate types (JSON)
+cargo run -- generate types -i spec.yaml -o types.rs   # Generate types (YAML)
 cargo run -- generate client -i spec.json -o client.rs # Generate client
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "url",
 ]
 
@@ -1559,6 +1560,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.12.1",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +1909,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 ]
 description = "A rust type generator for OpenAPI v3.1.x specification."
 edition = "2024"
-keywords = ["oas3", "json", "openapi", "rust", "generator"]
+keywords = ["oas3", "json", "yaml", "openapi", "generator"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/eklipse2k8/oas3-gen"
@@ -57,7 +57,7 @@ indexmap = { version = "2.12", features = ["serde"] }
 inflections = { version = "1.1" }
 json-canon = { version = "0.1" }
 num-format = { version = "0.4" }
-oas3 = { version = "0.20" }
+oas3 = { version = "0.20", features = ["yaml-spec"] }
 percent-encoding = { version = "2.3" }
 prettyplease = { version = "0.2" }
 proc-macro2 = { version = "1.0" }

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ cargo install oas3-gen
 
 ### 2. Generation
 
-Provide a path to an OpenAPI specification and specify an output file for the generated Rust code.
+Provide a path to an OpenAPI specification (JSON or YAML) and specify an output file for the generated Rust code. The format is auto-detected based on file extension.
 
 ```zsh
 # generate types (structs and enums)
 oas3-gen generate -i path/to/openapi.json -o path/to/types.rs
+oas3-gen generate -i path/to/openapi.yaml -o path/to/types.rs
 
 # generate client operations
 oas3-gen generate client -i path/to/openapi.json -o path/to/client.rs
@@ -79,6 +80,7 @@ pub struct Pet {
 | Doc Comments | Schema descriptions become rustdoc |
 | Enum Helpers | Ergonomic is_/as_ methods |
 | Enum Modes | Merge, preserve, or relaxed |
+| JSON/YAML Support | Auto-detects format from file extension |
 | OData Support | Optional @odata.* field handling |
 | OpenAPI 3.1 | Full spec parsing support |
 | Operation Filtering | Include/exclude specific operations |
@@ -120,7 +122,7 @@ Arguments:
   [MODE]  Sets the generation mode [default: types] [possible values: types, client]
 
 Required:
-  -i, --input <FILE>   Path to the OpenAPI specification file
+  -i, --input <FILE>   Path to the OpenAPI specification file (JSON or YAML, auto-detected)
   -o, --output <FILE>  Path for the generated rust output file
 
 Code Generation:
@@ -153,8 +155,9 @@ Options:
 ### Examples
 
 ```zsh
-# Basic usage to generate types
+# Basic usage to generate types (JSON or YAML auto-detected)
 oas3-gen generate types -i openapi.json -o types.rs
+oas3-gen generate types -i openapi.yaml -o types.rs
 
 # Basic usage to generate companion client
 oas3-gen generate client -i openapi.json -o client.rs

--- a/crates/oas3-gen/fixtures/schema.yaml
+++ b/crates/oas3-gen/fixtures/schema.yaml
@@ -1,0 +1,55 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    model:
+      type: object
+      properties:
+        one:
+          description: type array
+          type:
+            - integer
+            - string
+        two:
+          description: type 'null'
+          type: "null"
+        three:
+          description: type array including 'null'
+          type:
+            - string
+            - "null"
+        four:
+          description: array with no items
+          type: array
+        five:
+          description: singular example
+          type: string
+          examples:
+            - exampleValue
+        six:
+          description: exclusiveMinimum true
+          exclusiveMinimum: 10
+        seven:
+          description: exclusiveMinimum false
+          minimum: 10
+        eight:
+          description: exclusiveMaximum true
+          exclusiveMaximum: 20
+        nine:
+          description: exclusiveMaximum false
+          maximum: 20
+        ten:
+          description: nullable string
+          type:
+            - string
+            - "null"
+        eleven:
+          description: x-nullable string
+          type:
+            - string
+            - "null"
+        twelve:
+          description: file/binary

--- a/crates/oas3-gen/src/ui/commands/generate.rs
+++ b/crates/oas3-gen/src/ui/commands/generate.rs
@@ -2,8 +2,6 @@ use std::{collections::HashSet, path::PathBuf};
 
 use chrono::{Local, Timelike};
 use crossterm::style::Stylize;
-use fmmap::tokio::{AsyncMmapFile, AsyncMmapFileExt};
-use oas3::OpenApiV3Spec;
 
 use crate::{
   generator::{
@@ -11,6 +9,7 @@ use crate::{
     orchestrator::{GenerationStats, Orchestrator},
   },
   ui::{Colors, EnumCaseMode, GenerateMode},
+  utils::spec::SpecLoader,
 };
 
 fn format_timestamp() -> String {
@@ -77,9 +76,7 @@ impl GenerateConfig {
   }
 
   async fn load_spec(&self) -> anyhow::Result<oas3::Spec> {
-    let file = AsyncMmapFile::open(&self.input).await?;
-    let spec = serde_json::from_slice::<OpenApiV3Spec>(file.as_slice())?;
-    Ok(spec)
+    SpecLoader::open(&self.input).await?.parse()
   }
 
   fn create_orchestrator(&self, spec: oas3::Spec) -> Orchestrator {

--- a/crates/oas3-gen/src/ui/commands/list.rs
+++ b/crates/oas3-gen/src/ui/commands/list.rs
@@ -1,15 +1,15 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Row, Table};
 
 use crate::{
   generator::operation_registry::OperationRegistry,
   ui::{Colors, colors::IntoComfyColor, term_width},
+  utils::spec::SpecLoader,
 };
 
-pub async fn list_operations(input: &PathBuf, colors: &Colors) -> anyhow::Result<()> {
-  let file_content = tokio::fs::read_to_string(input).await?;
-  let spec: oas3::Spec = oas3::from_json(file_content)?;
+pub async fn list_operations(input: &Path, colors: &Colors) -> anyhow::Result<()> {
+  let spec = SpecLoader::open(input).await?.parse()?;
 
   let registry = OperationRegistry::from_spec(&spec);
 

--- a/crates/oas3-gen/src/utils/mod.rs
+++ b/crates/oas3-gen/src/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod spec;
 pub mod text;

--- a/crates/oas3-gen/src/utils/spec.rs
+++ b/crates/oas3-gen/src/utils/spec.rs
@@ -1,0 +1,49 @@
+use std::{ffi::OsStr, path::Path};
+
+use fmmap::tokio::{AsyncMmapFile, AsyncMmapFileExt};
+use oas3::OpenApiV3Spec;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SpecFormat {
+  #[default]
+  Json,
+  Yaml,
+}
+
+impl SpecFormat {
+  #[must_use]
+  pub fn from_extension(ext: &str) -> Self {
+    match ext {
+      "yaml" | "yml" => Self::Yaml,
+      _ => Self::Json,
+    }
+  }
+}
+
+pub struct SpecLoader {
+  file: AsyncMmapFile,
+  format: SpecFormat,
+}
+
+impl SpecLoader {
+  pub async fn open(path: &Path) -> anyhow::Result<Self> {
+    let format = path
+      .extension()
+      .and_then(OsStr::to_str)
+      .map_or(SpecFormat::default(), SpecFormat::from_extension);
+
+    let file = AsyncMmapFile::open(path).await?;
+
+    Ok(Self { file, format })
+  }
+
+  pub fn parse(&self) -> anyhow::Result<oas3::Spec> {
+    match self.format {
+      SpecFormat::Json => Ok(serde_json::from_slice::<OpenApiV3Spec>(self.file.as_slice())?),
+      SpecFormat::Yaml => {
+        let content = std::str::from_utf8(self.file.as_slice())?;
+        Ok(oas3::from_yaml(content)?)
+      }
+    }
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ Cargo workspace with two crates following a three-stage pipeline: **Parse OpenAP
 ```text
 crates/
 ├── oas3-gen/                      # CLI tool (binary)
-│   ├── fixtures/                  # Test fixtures
+│   ├── fixtures/                  # Test fixtures (JSON and YAML)
 │   │   ├── basic_api.json         # Basic API test fixture
 │   │   ├── content_types.json     # Content type handling tests
 │   │   ├── enum_deduplication.json # Enum deduplication tests
@@ -16,6 +16,7 @@ crates/
 │   │   ├── operation_filtering.json # Operation filtering tests
 │   │   ├── petstore.json          # Petstore API specification
 │   │   ├── relaxed_enum_deduplication.json # Relaxed enum deduplication tests
+│   │   ├── schema.yaml            # YAML format test fixture
 │   │   └── petstore/              # Petstore generated output fixtures
 │   │       ├── mod.rs
 │   │       ├── client.rs
@@ -139,7 +140,7 @@ crates/
 
 ## Generation Pipeline
 
-1. **Parse**: Load OpenAPI spec via `oas3` crate
+1. **Parse**: Load OpenAPI spec via `oas3` crate (JSON or YAML, auto-detected from file extension)
 2. **Analyze**: Build schema dependency graph, detect cycles
 3. **Convert**: Transform schemas to AST (`converter/`)
 4. **Generate**: Produce formatted Rust code (`codegen/`)
@@ -161,7 +162,7 @@ All dependencies are managed at the workspace level in the root `Cargo.toml` and
 
 ### Code Generation
 
-- **oas3** (0.20): OpenAPI 3.1 spec parser
+- **oas3** (0.20): OpenAPI 3.1 spec parser with JSON and YAML support
 - **quote** (1.0): Token stream generation
 - **proc-macro2** (1.0): Token manipulation
 - **syn** (2.0): Rust syntax parser with full parsing support

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,8 +20,9 @@ cargo build
 The application uses a CLI interface powered by `clap` with subcommands:
 
 ```bash
-# Generate Rust types from OpenAPI spec (default mode)
+# Generate Rust types from OpenAPI spec (default mode, JSON or YAML auto-detected)
 cargo run -- generate types -i spec.json -o generated.rs
+cargo run -- generate types -i spec.yaml -o generated.rs
 
 # Generate HTTP client from OpenAPI spec
 cargo run -- generate client -i spec.json -o client.rs
@@ -54,7 +55,7 @@ cargo run -- list --help
 | Argument/Option | Description |
 |-----------------|-------------|
 | `[MODE]` | Generation mode: `types` (default) or `client` |
-| `--input` / `-i` | (Required) Path to OpenAPI JSON specification file |
+| `--input` / `-i` | (Required) Path to OpenAPI specification file (JSON or YAML, auto-detected) |
 | `--output` / `-o` | (Required) Path where generated Rust code will be written |
 | `--visibility` / `-C` | Visibility level for generated types (public, crate, or file; default: public) |
 | `--odata-support` | Enable OData-specific field optionality rules (makes @odata.* fields optional on concrete types) |


### PR DESCRIPTION
Auto-detect input format based on file extension (.yaml/.yml vs .json).
Both generate and list commands now support YAML specifications through the oas3 yaml-spec feature.