### PR TITLE
fix: reachability for path params

### DIFF
--- a/crates/oas3-gen/fixtures/path_level_params.json
+++ b/crates/oas3-gen/fixtures/path_level_params.json
@@ -1,0 +1,132 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Path-level parameters reachability test",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/offices/{officeId}": {
+      "parameters": [
+        { "$ref": "#/components/parameters/OfficeId" }
+      ],
+      "get": {
+        "operationId": "getOffice",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/offices/{officeId}/briefing": {
+      "parameters": [
+        { "$ref": "#/components/parameters/OfficeId" }
+      ],
+      "get": {
+        "operationId": "getOfficeBriefing",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "summary": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items": {
+      "get": {
+        "operationId": "listItems",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "query",
+            "schema": { "$ref": "#/components/schemas/ItemCategory" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "OfficeId": {
+        "name": "officeId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/OfficeIdUnion"
+        }
+      }
+    },
+    "schemas": {
+      "ForecastOfficeId": {
+        "type": "string",
+        "description": "Forecast office identifier",
+        "enum": ["AKQ", "ALY", "BGM"]
+      },
+      "RegionalHQId": {
+        "type": "string",
+        "description": "Regional HQ identifier",
+        "enum": ["ARH", "CRH", "ERH"]
+      },
+      "NationalHQId": {
+        "type": "string",
+        "description": "National HQ identifier",
+        "enum": ["NHQ"]
+      },
+      "OfficeIdUnion": {
+        "description": "Any office identifier",
+        "oneOf": [
+          { "$ref": "#/components/schemas/ForecastOfficeId" },
+          { "$ref": "#/components/schemas/RegionalHQId" },
+          { "$ref": "#/components/schemas/NationalHQId" }
+        ]
+      },
+      "ItemCategory": {
+        "type": "string",
+        "enum": ["electronics", "clothing", "food"]
+      },
+      "UnreferencedSchema": {
+        "type": "object",
+        "properties": {
+          "data": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/crates/oas3-gen/src/generator/schema_registry.rs
+++ b/crates/oas3-gen/src/generator/schema_registry.rs
@@ -486,7 +486,7 @@ impl SchemaRegistry {
   ) -> BTreeSet<String> {
     let initial_refs = operation_registry
       .operations()
-      .flat_map(|entry| self.collect_refs_from_operation(&entry.operation, union_fingerprints))
+      .flat_map(|entry| self.collect_refs_from_operation(&entry.path, &entry.operation, union_fingerprints))
       .collect::<BTreeSet<_>>();
 
     let graph = DiGraphMap::<&str, ()>::from_edges(
@@ -801,18 +801,27 @@ impl SchemaRegistry {
     }
   }
 
-  /// Collects schema references from an operation.
+  /// Collects schema references from an operation and its path-level parameters.
   ///
-  /// Scans parameters, request bodies, and responses to identify all
-  /// schema references that an operation directly depends on.
+  /// Scans both path-level and operation-level parameters, request bodies, and
+  /// responses to identify all schema references that an operation depends on.
   fn collect_refs_from_operation(
     &self,
+    path: &str,
     operation: &Operation,
     union_fingerprints: &UnionFingerprints,
   ) -> BTreeSet<String> {
     let mut refs = BTreeSet::new();
 
-    for param in &operation.parameters {
+    let path_params = self
+      .spec
+      .paths
+      .as_ref()
+      .and_then(|p| p.get(path))
+      .map(|item| item.parameters.as_slice())
+      .unwrap_or_default();
+
+    for param in path_params.iter().chain(&operation.parameters) {
       if let Ok(resolved_param) = param.resolve(&self.spec)
         && let Some(ref schema_ref) = resolved_param.schema
       {

--- a/crates/oas3-gen/src/generator/tests/mod.rs
+++ b/crates/oas3-gen/src/generator/tests/mod.rs
@@ -1,5 +1,6 @@
 mod operation_registry;
 mod orchestrator;
+mod path_level_params;
 mod schema_graph;
 mod support;
 mod undeclared_path_params;

--- a/crates/oas3-gen/src/generator/tests/path_level_params.rs
+++ b/crates/oas3-gen/src/generator/tests/path_level_params.rs
@@ -1,0 +1,88 @@
+use super::support::{
+  assert_contains, assert_contains_all, assert_not_contains, generate_types, make_orchestrator, parse_spec,
+};
+
+const SPEC: &str = include_str!("../../../fixtures/path_level_params.json");
+
+#[test]
+fn path_level_param_oneof_schema_is_emitted() {
+  let orchestrator = make_orchestrator(parse_spec(SPEC), false);
+  let output = generate_types(&orchestrator, "test.json");
+
+  assert_contains_all(
+    &output.code,
+    &[
+      ("pub enum OfficeIdUnion", "oneOf union type should be emitted"),
+      ("ForecastOffice(ForecastOfficeId)", "first variant should reference ForecastOfficeId"),
+      ("RegionalHQ(RegionalHQId)", "second variant should reference RegionalHQId"),
+      ("NationalHQ(NationalHQId)", "third variant should reference NationalHQId"),
+    ],
+  );
+}
+
+#[test]
+fn path_level_param_transitive_deps_are_reachable() {
+  let orchestrator = make_orchestrator(parse_spec(SPEC), false);
+  let output = generate_types(&orchestrator, "test.json");
+
+  assert_contains_all(
+    &output.code,
+    &[
+      ("pub enum ForecastOfficeId", "leaf enum ForecastOfficeId should be emitted"),
+      ("pub enum RegionalHQId", "leaf enum RegionalHQId should be emitted"),
+      ("pub enum NationalHQId", "leaf enum NationalHQId should be emitted"),
+    ],
+  );
+}
+
+#[test]
+fn path_level_param_generates_typed_field() {
+  let orchestrator = make_orchestrator(parse_spec(SPEC), false);
+  let output = generate_types(&orchestrator, "test.json");
+
+  assert_contains(
+    &output.code,
+    "office_id: Box<OfficeIdUnion>",
+    "request path struct should have typed office_id field",
+  );
+}
+
+#[test]
+fn operation_level_params_still_reachable() {
+  let orchestrator = make_orchestrator(parse_spec(SPEC), false);
+  let output = generate_types(&orchestrator, "test.json");
+
+  assert_contains(
+    &output.code,
+    "pub enum ItemCategory",
+    "operation-level param schema should be emitted",
+  );
+}
+
+#[test]
+fn unreferenced_schemas_excluded_without_all_schemas() {
+  let orchestrator = make_orchestrator(parse_spec(SPEC), false);
+  let output = generate_types(&orchestrator, "test.json");
+
+  assert_not_contains(
+    &output.code,
+    "UnreferencedSchema",
+    "unreferenced schema should be excluded when not using --all-schemas",
+  );
+}
+
+#[test]
+fn all_schemas_mode_includes_everything() {
+  let orchestrator = make_orchestrator(parse_spec(SPEC), true);
+  let output = generate_types(&orchestrator, "test.json");
+
+  assert_contains_all(
+    &output.code,
+    &[
+      ("pub enum OfficeIdUnion", "oneOf union should be emitted in all-schemas mode"),
+      ("pub enum ForecastOfficeId", "ForecastOfficeId should be emitted"),
+      ("pub enum ItemCategory", "ItemCategory should be emitted"),
+      ("UnreferencedSchema", "unreferenced schema should be included in all-schemas mode"),
+    ],
+  );
+}


### PR DESCRIPTION
Path-level parameters (defined on `PathItem`, not `Operation`) were excluded from the schema reachability scan, causing their `$ref` targets to be silently dropped when generating without `--all-schemas`.  This manifested as "cannot find type" errors for `oneOf` schemas referenced exclusively through path-level parameters (e.g. `NWSOfficeId` in the weather.gov spec)