### PR TITLE
fix: round float-encoded integer range bounds to integer literals

### DIFF
--- a/crates/oas3-gen/src/generator/ast/mod.rs
+++ b/crates/oas3-gen/src/generator/ast/mod.rs
@@ -37,7 +37,7 @@ pub use status_codes::StatusCodeToken;
 pub use tokens::{
   DefaultAtom, EnumToken, EnumVariantToken, FieldNameToken, MethodNameToken, StructToken, TraitToken, TypeAliasToken,
 };
-pub use types::{RustPrimitive, TypeRef};
+pub use types::{Rounding, RustPrimitive, TypeRef};
 pub use validation_attrs::{RegexKey, ValidationAttribute};
 
 pub use crate::generator::ast::fields::{FieldCollection, FieldDef};

--- a/crates/oas3-gen/src/generator/ast/tests/validation_attrs.rs
+++ b/crates/oas3-gen/src/generator/ast/tests/validation_attrs.rs
@@ -66,6 +66,42 @@ fn test_validation_attribute_range_display() {
     attr_float.to_token_stream().to_string(),
     "range (min = 0.5 , max = 1.0)"
   );
+
+  let attr_float_encoded_int = ValidationAttribute::Range {
+    primitive: RustPrimitive::I64,
+    min: Some(serde_json::json!(-1.0).as_number().unwrap().clone()),
+    max: Some(serde_json::json!(1.0).as_number().unwrap().clone()),
+    exclusive_min: None,
+    exclusive_max: None,
+  };
+  assert_eq!(
+    attr_float_encoded_int.to_token_stream().to_string(),
+    "range (min = - 1i64 , max = 1i64)"
+  );
+
+  let attr_fractional = ValidationAttribute::Range {
+    primitive: RustPrimitive::I64,
+    min: Some(serde_json::json!(1.5).as_number().unwrap().clone()),
+    max: Some(serde_json::json!(2.5).as_number().unwrap().clone()),
+    exclusive_min: None,
+    exclusive_max: None,
+  };
+  assert_eq!(
+    attr_fractional.to_token_stream().to_string(),
+    "range (min = 2i64 , max = 2i64)"
+  );
+
+  let attr_fractional_exclusive = ValidationAttribute::Range {
+    primitive: RustPrimitive::I64,
+    min: None,
+    max: None,
+    exclusive_min: Some(serde_json::json!(1.5).as_number().unwrap().clone()),
+    exclusive_max: Some(serde_json::json!(2.5).as_number().unwrap().clone()),
+  };
+  assert_eq!(
+    attr_fractional_exclusive.to_token_stream().to_string(),
+    "range (exclusive_min = 1i64 , exclusive_max = 3i64)"
+  );
 }
 
 #[test]

--- a/crates/oas3-gen/src/generator/ast/types.rs
+++ b/crates/oas3-gen/src/generator/ast/types.rs
@@ -187,6 +187,13 @@ impl From<&serde_json::Value> for TypeRef {
   }
 }
 
+/// Direction for rounding a float-encoded bound to an integer literal
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rounding {
+  Ceil,
+  Floor,
+}
+
 /// Rust primitive and standard library types
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default, strum::Display)]
 #[strum(serialize_all = "lowercase")]
@@ -323,6 +330,29 @@ impl RustPrimitive {
     } else {
       num.to_string()
     }
+  }
+
+  pub fn format_range_bound(&self, num: &Number, rounding: Rounding) -> String {
+    if self.is_float() {
+      return self.format_number(num);
+    }
+    if let Some(value) = num.as_i64() {
+      return render_integer(self, value);
+    }
+    if let Some(value) = num.as_u64() {
+      return render_unsigned_integer(self, value);
+    }
+    if let Some(f) = num.as_f64() {
+      let rounded = match rounding {
+        Rounding::Ceil => f.ceil(),
+        Rounding::Floor => f.floor(),
+      };
+      #[allow(clippy::cast_possible_truncation)]
+      if rounded >= i64::MIN as f64 && rounded <= i64::MAX as f64 {
+        return render_integer(self, rounded as i64);
+      }
+    }
+    num.to_string()
   }
 
   fn format_string_value(&self, s: &str) -> String {

--- a/crates/oas3-gen/src/generator/ast/validation_attrs.rs
+++ b/crates/oas3-gen/src/generator/ast/validation_attrs.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use serde_json::Number;
 
-use crate::generator::ast::{RustPrimitive, StructToken, TypeRef, types::render_unsigned_integer};
+use crate::generator::ast::{Rounding, RustPrimitive, StructToken, TypeRef, types::render_unsigned_integer};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RegexKey {
@@ -185,19 +185,31 @@ impl ToTokens for ValidationAttribute {
       } => {
         let mut parts = vec![];
         if let Some(m) = min {
-          let lit = primitive.format_number(m).parse::<TokenStream>().unwrap();
+          let lit = primitive
+            .format_range_bound(m, Rounding::Ceil)
+            .parse::<TokenStream>()
+            .unwrap();
           parts.push(quote! { min = #lit });
         }
         if let Some(m) = max {
-          let lit = primitive.format_number(m).parse::<TokenStream>().unwrap();
+          let lit = primitive
+            .format_range_bound(m, Rounding::Floor)
+            .parse::<TokenStream>()
+            .unwrap();
           parts.push(quote! { max = #lit });
         }
         if let Some(m) = exclusive_min {
-          let lit = primitive.format_number(m).parse::<TokenStream>().unwrap();
+          let lit = primitive
+            .format_range_bound(m, Rounding::Floor)
+            .parse::<TokenStream>()
+            .unwrap();
           parts.push(quote! { exclusive_min = #lit });
         }
         if let Some(m) = exclusive_max {
-          let lit = primitive.format_number(m).parse::<TokenStream>().unwrap();
+          let lit = primitive
+            .format_range_bound(m, Rounding::Ceil)
+            .parse::<TokenStream>()
+            .unwrap();
           parts.push(quote! { exclusive_max = #lit });
         }
         quote! { range(#(#parts),*) }


### PR DESCRIPTION
A range keyword's value [must be a number](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.4), and a [JSON number](https://www.rfc-editor.org/rfc/rfc8259#section-6) may carry a fraction, so `minimum: -1.0` on a `type: integer` field is valid ([OpenAPI 3.1's Schema Object is a superset of JSON Schema 2020-12](https://spec.openapis.org/oas/v3.1.0#data-types)). `serde_json` parses `-1.0` as a float `Number`, so `as_i64()`/`as_u64()` return `None` and `format_number` fell through to `num.to_string()`, emitting a float literal into `#[validate(range(...))]` on an `i64` field, which doesn't compile.

Since an integer field admits no fractional part, each bound rounds to the integer literal that preserves the constraint exactly:

| keyword | rounding |
| --- | --- |
| `minimum` | ceil |
| `maximum` | floor |
| `exclusiveMinimum` | floor |
| `exclusiveMaximum` | ceil |

Integer-valued bounds are unaffected; fractional bounds, previously a compile error, now round (`minimum: 1.5` becomes `min = 2`).

Closes #90