### PR TITLE
fix: header map insert/extract must match rendered field optionality (#92)

### DIFF
--- a/crates/oas3-gen/fixtures/petstore.json
+++ b/crates/oas3-gen/fixtures/petstore.json
@@ -59,6 +59,17 @@
 								"enum": ["cat", "dog", "fish", "bird"]
 							}
 						}
+					},
+					{
+						"name": "x-compatibility-date",
+						"in": "header",
+						"description": "API compatibility date",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "date",
+							"enum": ["2026-06-09"]
+						}
 					}
 				],
 				"responses": {

--- a/crates/oas3-gen/fixtures/petstore/types.rs
+++ b/crates/oas3-gen/fixtures/petstore/types.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 pub const X_SORT_ORDER: http::HeaderName = http::HeaderName::from_static("x-sort-order");
 pub const X_ONLY: http::HeaderName = http::HeaderName::from_static("x-only");
+pub const X_COMPATIBILITY_DATE: http::HeaderName = http::HeaderName::from_static("x-compatibility-date");
 pub const X_API_VERSION: http::HeaderName = http::HeaderName::from_static("x-api-version");
 pub const X_API_KEY: http::HeaderName = http::HeaderName::from_static("x-api-key");
 #[derive(Debug, Clone, PartialEq, Deserialize, oas3_gen_support::Default, bon::Builder)]
@@ -130,11 +131,14 @@ pub struct ListPetsRequestHeader {
   pub x_sort_order: Option<ListPetsRequestHeaderXSortOrder>,
   /// Only include pets with a tag
   pub x_only: Option<Vec<ListPetsRequestHeaderXonly>>,
+  /// API compatibility date
+  #[default(Default::default())]
+  pub x_compatibility_date: chrono::NaiveDate,
 }
 impl core::convert::TryFrom<&ListPetsRequestHeader> for http::HeaderMap {
   type Error = http::header::InvalidHeaderValue;
   fn try_from(headers: &ListPetsRequestHeader) -> core::result::Result<Self, Self::Error> {
-    let mut map = http::HeaderMap::with_capacity(2usize);
+    let mut map = http::HeaderMap::with_capacity(3usize);
     if let Some(value) = &headers.x_sort_order {
       let header_value = http::HeaderValue::try_from(value.to_string())?;
       map.insert(X_SORT_ORDER, header_value);
@@ -149,6 +153,8 @@ impl core::convert::TryFrom<&ListPetsRequestHeader> for http::HeaderMap {
       )?;
       map.insert(X_ONLY, header_value);
     }
+    let header_value = http::HeaderValue::try_from(&headers.x_compatibility_date.to_string())?;
+    map.insert(X_COMPATIBILITY_DATE, header_value);
     Ok(map)
   }
 }
@@ -176,11 +182,16 @@ impl ListPetsRequest {
     limit: Option<i32>,
     x_sort_order: Option<ListPetsRequestHeaderXSortOrder>,
     x_only: Option<Vec<ListPetsRequestHeaderXonly>>,
+    x_compatibility_date: chrono::NaiveDate,
   ) -> anyhow::Result<Self> {
     let request = Self {
       path: ListPetsRequestPath { api_version },
       query: ListPetsRequestQuery { limit },
-      header: ListPetsRequestHeader { x_sort_order, x_only },
+      header: ListPetsRequestHeader {
+        x_sort_order,
+        x_only,
+        x_compatibility_date,
+      },
     };
     request.validate()?;
     Ok(request)

--- a/crates/oas3-gen/fixtures/petstore_server/types.rs
+++ b/crates/oas3-gen/fixtures/petstore_server/types.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 pub const X_SORT_ORDER: http::HeaderName = http::HeaderName::from_static("x-sort-order");
 pub const X_ONLY: http::HeaderName = http::HeaderName::from_static("x-only");
+pub const X_COMPATIBILITY_DATE: http::HeaderName = http::HeaderName::from_static("x-compatibility-date");
 pub const X_API_VERSION: http::HeaderName = http::HeaderName::from_static("x-api-version");
 pub const X_API_KEY: http::HeaderName = http::HeaderName::from_static("x-api-key");
 #[serde_with::skip_serializing_none]
@@ -124,11 +125,14 @@ pub struct ListPetsRequestHeader {
   pub x_sort_order: Option<ListPetsRequestHeaderXSortOrder>,
   /// Only include pets with a tag
   pub x_only: Option<Vec<ListPetsRequestHeaderXonly>>,
+  /// API compatibility date
+  #[default(Default::default())]
+  pub x_compatibility_date: chrono::NaiveDate,
 }
 impl core::convert::TryFrom<&ListPetsRequestHeader> for http::HeaderMap {
   type Error = http::header::InvalidHeaderValue;
   fn try_from(headers: &ListPetsRequestHeader) -> core::result::Result<Self, Self::Error> {
-    let mut map = http::HeaderMap::with_capacity(2usize);
+    let mut map = http::HeaderMap::with_capacity(3usize);
     if let Some(value) = &headers.x_sort_order {
       let header_value = http::HeaderValue::try_from(value.to_string())?;
       map.insert(X_SORT_ORDER, header_value);
@@ -143,6 +147,8 @@ impl core::convert::TryFrom<&ListPetsRequestHeader> for http::HeaderMap {
       )?;
       map.insert(X_ONLY, header_value);
     }
+    let header_value = http::HeaderValue::try_from(&headers.x_compatibility_date.to_string())?;
+    map.insert(X_COMPATIBILITY_DATE, header_value);
     Ok(map)
   }
 }
@@ -164,6 +170,11 @@ impl core::convert::TryFrom<&http::HeaderMap> for ListPetsRequestHeader {
         .get(X_ONLY)
         .and_then(|v| v.to_str().ok())
         .map(|value| value.split(',').map(str::trim).filter_map(|s| s.parse().ok()).collect()),
+      x_compatibility_date: headers
+        .get(X_COMPATIBILITY_DATE)
+        .and_then(|v| v.to_str().ok())
+        .map(|value| value.parse().unwrap_or_default())
+        .unwrap_or_default(),
     })
   }
 }
@@ -191,11 +202,16 @@ impl ListPetsRequest {
     limit: Option<i32>,
     x_sort_order: Option<ListPetsRequestHeaderXSortOrder>,
     x_only: Option<Vec<ListPetsRequestHeaderXonly>>,
+    x_compatibility_date: chrono::NaiveDate,
   ) -> anyhow::Result<Self> {
     let request = Self {
       path: ListPetsRequestPath { api_version },
       query: ListPetsRequestQuery { limit },
-      header: ListPetsRequestHeader { x_sort_order, x_only },
+      header: ListPetsRequestHeader {
+        x_sort_order,
+        x_only,
+        x_compatibility_date,
+      },
     };
     request.validate()?;
     Ok(request)

--- a/crates/oas3-gen/src/generator/codegen/headers.rs
+++ b/crates/oas3-gen/src/generator/codegen/headers.rs
@@ -77,19 +77,19 @@ impl ToTokens for HeaderFieldInsertionFragment {
     let header_const = ConstToken::from_raw(original_name);
     let ty = &self.field.rust_type;
 
-    let insertion = if self.field.is_required() {
-      let header_value = header_value_expr(ty, quote! { &headers.#field_name });
-      quote! {
-        let header_value = http::HeaderValue::try_from(#header_value)?;
-        map.insert(#header_const, header_value);
-      }
-    } else {
+    let insertion = if self.field.rust_type.nullable {
       let header_value = header_value_expr(ty, quote! { value });
       quote! {
         if let Some(value) = &headers.#field_name {
           let header_value = http::HeaderValue::try_from(#header_value)?;
           map.insert(#header_const, header_value);
         }
+      }
+    } else {
+      let header_value = header_value_expr(ty, quote! { &headers.#field_name });
+      quote! {
+        let header_value = http::HeaderValue::try_from(#header_value)?;
+        map.insert(#header_const, header_value);
       }
     };
 
@@ -180,7 +180,7 @@ impl ToTokens for HeaderFieldExtractionFragment {
 
     let header_const = ConstToken::from_raw(original_name);
     let parse_expr = header_parse_expr(&self.field.rust_type, &quote! { value });
-    let default_suffix = self.field.is_required().then(|| quote! { .unwrap_or_default() });
+    let default_suffix = (!self.field.rust_type.nullable).then(|| quote! { .unwrap_or_default() });
 
     tokens.extend(quote! {
       #field_name: headers

--- a/crates/oas3-gen/src/generator/codegen/tests/struct_tests.rs
+++ b/crates/oas3-gen/src/generator/codegen/tests/struct_tests.rs
@@ -287,6 +287,49 @@ fn test_header_params_struct_generates_try_from_header_map() {
 }
 
 #[test]
+fn test_required_header_with_default_uses_unconditional_insert() {
+  let def = StructDef {
+    name: StructToken::new("RequestHeader"),
+    docs: Documentation::default(),
+    fields: vec![
+      FieldDef::builder()
+        .name(FieldNameToken::new("x_compatibility_date"))
+        .rust_type(TypeRef::new("String"))
+        .default_value(serde_json::Value::String("2026-06-09".to_string()))
+        .original_name("X-Compatibility-Date")
+        .build(),
+    ],
+    kind: StructKind::HeaderParams,
+    ..Default::default()
+  };
+
+  let client_code = StructFragment::new(
+    def.clone(),
+    BTreeMap::new(),
+    Visibility::Public,
+    GenerationTarget::Client,
+  )
+  .into_token_stream()
+  .to_string();
+  assert!(
+    !client_code.contains("if let Some"),
+    "required field with default must use unconditional insert: {client_code}"
+  );
+  assert!(
+    client_code.contains("map . insert (X_COMPATIBILITY_DATE"),
+    "missing header insert: {client_code}"
+  );
+
+  let server_code = StructFragment::new(def, BTreeMap::new(), Visibility::Public, GenerationTarget::Server)
+    .into_token_stream()
+    .to_string();
+  assert!(
+    server_code.contains(". unwrap_or_default ()"),
+    "required field with default must unwrap extraction: {server_code}"
+  );
+}
+
+#[test]
 fn test_non_header_params_struct_does_not_generate_try_from_header_map() {
   let def = base_struct(StructKind::Schema);
   let tokens =

--- a/crates/oas3-gen/src/tests/petstore.rs
+++ b/crates/oas3-gen/src/tests/petstore.rs
@@ -9,6 +9,7 @@ fn test_list_pets_request_compiles() {
     .api_version("v1".to_string())
     .x_sort_order(ListPetsRequestHeaderXSortOrder::Asc)
     .x_only(vec![ListPetsRequestHeaderXonly::Bird, ListPetsRequestHeaderXonly::Fish])
+    .x_compatibility_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap())
     .limit(50)
     .build();
   assert!(request.is_ok(), "request should be valid");
@@ -25,6 +26,11 @@ fn test_list_pets_request_compiles() {
     headers.get("x-only").unwrap().to_str().unwrap(),
     "bird,fish",
     "header map should contain x-only values"
+  );
+  assert_eq!(
+    headers.get("x-compatibility-date").unwrap().to_str().unwrap(),
+    "2026-06-09",
+    "header map should contain required x-compatibility-date"
   );
 }
 

--- a/crates/oas3-gen/src/tests/petstore_server.rs
+++ b/crates/oas3-gen/src/tests/petstore_server.rs
@@ -10,6 +10,7 @@ fn test_list_pets_request_compiles() {
     .api_version("v1".to_string())
     .x_sort_order(ListPetsRequestHeaderXSortOrder::Asc)
     .x_only(vec![ListPetsRequestHeaderXonly::Bird, ListPetsRequestHeaderXonly::Fish])
+    .x_compatibility_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap())
     .limit(50)
     .build();
   assert!(request.is_ok(), "request should be valid");
@@ -26,6 +27,11 @@ fn test_list_pets_request_compiles() {
     headers.get("x-only").unwrap().to_str().unwrap(),
     "bird,fish",
     "header map should contain x-only values"
+  );
+  assert_eq!(
+    headers.get("x-compatibility-date").unwrap().to_str().unwrap(),
+    "2026-06-09",
+    "header map should contain required x-compatibility-date"
   );
 }
 


### PR DESCRIPTION
Fixes #92.

A required header parameter whose schema carries a `default`, `const`, or single-value `enum` generated code that failed to compile with `E0308`: the struct field rendered as bare `T` (optionality driven by `rust_type.nullable`), while the `TryFrom<&…RequestHeader> for HeaderMap` insert rendered `if let Some(...)` (driven by `FieldDef::is_required()`, which also returns `false` when a default is present).

This also affected the reverse, server-only direction: `TryFrom<&HeaderMap>` gated `.unwrap_or_default()` on the same predicate, assigning `Option<T>` to a bare `T` field.

Both codegen sites in `codegen/headers.rs` now key on `rust_type.nullable`, the same predicate that determines the rendered field type, so the two outputs can no longer diverge. `is_required()` itself is unchanged — its other callers (`converter/methods.rs`, `ast/mod.rs::required_fields`) are builder-facing and out of scope.

Tests:
- New unit test covering both directions for a non-nullable field with a default (`struct_tests.rs`).
- Required single-value-enum header (`x-compatibility-date`) added to the petstore fixture, which compiles under `cargo test` — a compile-level regression test for both client and server output, exercising the exact trigger from the EVE ESI spec where this was found.

Note: fixture updates were applied as targeted hunks rather than a full regeneration — regenerating petstore fixtures on a clean checkout of `main` already produces a large unrelated diff (indentation and style drift vs the checked-in files), which I kept out of this PR.